### PR TITLE
Update SQLite CVE-2022-35737 build files

### DIFF
--- a/disclosures/CVE-2022-35737/Dockerfile
+++ b/disclosures/CVE-2022-35737/Dockerfile
@@ -32,3 +32,5 @@ WORKDIR /poc
 ENV C_INCLUDE_PATH=/sqlite3/build-optimized \
     LD_FLAGS="-L/sqlite3/build-optimized/.libs"
 RUN make
+
+RUN apt-get install -y gdb

--- a/disclosures/CVE-2022-35737/Dockerfile
+++ b/disclosures/CVE-2022-35737/Dockerfile
@@ -7,13 +7,21 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Pin to SQLite install to vulnerable version.
 RUN apt-get update && \
-    apt-get install -y \
-        build-essential \
-        libsqlite3-dev=3.31.1-4ubuntu0.3 \
-        php-cli \
-        php-pdo-sqlite
+    apt-get install -y build-essential wget git vim tclsh
+
+WORKDIR /sqlite3
+RUN git clone git://git.launchpad.net/ubuntu/+source/sqlite3 src
+WORKDIR /sqlite3/src
+RUN git checkout applied/3.31.1-4ubuntu0.3
+WORKDIR /sqlite3/build-optimized
+RUN ../src/configure --enable-shared && make
+WORKDIR /sqlite3/build-unoptimized
+ENV CFLAGS="-g -O0"
+RUN ../src/configure --enable-shared && make
 
 COPY ./ /poc
 WORKDIR /poc
 
+ENV C_INCLUDE_PATH=/sqlite3/build-optimized \
+    LD_FLAGS="-L/sqlite3/build-optimized/.libs"
 RUN make

--- a/disclosures/CVE-2022-35737/Dockerfile
+++ b/disclosures/CVE-2022-35737/Dockerfile
@@ -5,23 +5,30 @@ FROM ubuntu:20.04
 ENV TZ=America/New_York
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-# Pin to SQLite install to vulnerable version.
+# Install dependencies.
 RUN apt-get update && \
     apt-get install -y build-essential wget git vim tclsh
 
+# Vulnerable version of SQLite has been removed from the Apt repository
+# (sqlite3-dev=3.31.1-4ubuntu0.3). Instead, build the vulnerable version from
+# source using the Apt maintainer's source files.
 WORKDIR /sqlite3
 RUN git clone git://git.launchpad.net/ubuntu/+source/sqlite3 src
 WORKDIR /sqlite3/src
 RUN git checkout applied/3.31.1-4ubuntu0.3
+
+# Build an optimized version of the vulnerable library.
 WORKDIR /sqlite3/build-optimized
 RUN ../src/configure --enable-shared && make
+
+# Build an unoptimized version of the vulnerable library.
 WORKDIR /sqlite3/build-unoptimized
 ENV CFLAGS="-g -O0"
 RUN ../src/configure --enable-shared && make
 
+# Build proofs-of-concept.
 COPY ./ /poc
 WORKDIR /poc
-
 ENV C_INCLUDE_PATH=/sqlite3/build-optimized \
     LD_FLAGS="-L/sqlite3/build-optimized/.libs"
 RUN make

--- a/disclosures/CVE-2022-35737/Makefile
+++ b/disclosures/CVE-2022-35737/Makefile
@@ -5,16 +5,16 @@ LIBS=-lsqlite3
 all: snprintf-crash snprintf-control-pc snprintf-livelock snprintf-good-example
 
 snprintf-crash: snprintf-crash.c
-	$(CC) -o $@ $^ $(LIBS)
+	$(CC) $(LD_FLAGS) -o $@ $^ $(LIBS)
 
 snprintf-control-pc: snprintf-control-pc.c
-	$(CC) -o $@ $^ $(LIBS)
+	$(CC) $(LD_FLAGS) -o $@ $^ $(LIBS)
 
 snprintf-livelock: snprintf-livelock.c
-	$(CC) -o $@ $^ $(LIBS)
+	$(CC) $(LD_FLAGS) -o $@ $^ $(LIBS)
 
 snprintf-good-example: snprintf-good-example.c
-	$(CC) -o $@ $^ $(LIBS)
+	$(CC) $(LD_FLAGS) -o $@ $^ $(LIBS)
 
 clean:
 	$(RM) snprintf-crash snprintf-control-pc snprintf-livelock snprintf-good-example

--- a/disclosures/CVE-2022-35737/README.md
+++ b/disclosures/CVE-2022-35737/README.md
@@ -94,6 +94,6 @@ has dependencies pinned to the vulnerable version of the SQLite library.
 ```
 $ docker build -t cve-2022-35737 .
 $ docker run -it --rm cve-2022-35737 /bin/bash
-root@289cef859649:/poc# ./snprintf-crash
+root@289cef859649:/poc# LD_PRELOAD=/sqlite3/build-optimized/.libs/libsqlite3.so ./snprintf-crash
 Segmentation fault (core dumped)
 ```


### PR DESCRIPTION
Apt has removed the vulnerable version of SQLite from its package repository. This updates the Dockerfile to build the vulnerable library from source so that researchers can create a consistent build environment to demo the proof-of-concept exploits.