### PR TITLE
Fix incorrect relative path to presentation PDF

### DIFF
--- a/presentations/Modern iOS Application Security/README.md
+++ b/presentations/Modern iOS Application Security/README.md
@@ -3,7 +3,7 @@
 iOS applications have become an increasingly popular targets for hackers, reverse engineers, and software pirates. In this presentation, we discuss the current state of iOS attacks, review available security APIs, and reveal why they are not enough to defend against known threats. For high-risk applications, novel protections that go beyond those offered by Apple are required. As a solution, we discuss the design of the [Mobile Application Security Toolkit (MAST)](https://www.trailofbits.com/products/#mast) which ties together jailbreak detection, anti-debugging, and anti-reversing in LLVM to address these risks.
 
 Resources
-* [Slides](/iOS%20Application%20Security/iOS%20Application%20Security_notes.pdf), [Etsy Video](http://original.livestream.com/etsycodeascraft/video?clipId=pla_d62e2a22-e7b8-4140-9b92-44c41c07c1cb), [QCon Video](https://www.infoq.com/presentations/ios-security)
+* [Slides](iOS%20Application%20Security_notes.pdf), [Etsy Video](http://original.livestream.com/etsycodeascraft/video?clipId=pla_d62e2a22-e7b8-4140-9b92-44c41c07c1cb), [QCon Video](https://www.infoq.com/presentations/ios-security)
 * [MAST](https://www.appsecuritytoolkit.com/), the Mobile Application Security Toolkit
 * [ReMASTering Applications by Obfuscating during Compilation](https://blog.trailofbits.com/2014/08/20/remastering-applications-by-obfuscating-during-compilation/)
 


### PR DESCRIPTION
Corrected the broken relative link to iOS Application Security_notes.pdf in the README.md. The previous path incorrectly pointed to a subdirectory, while the file is located in the same directory as the markdown file. This fix ensures the Slides link renders and downloads correctly.