### PR TITLE
Add 4 missing podcast appearances

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@
 | [Risky Biz 786](https://youtu.be/DNAOwukOQi4?si=4KPfY2RnPMxVwSJJ&t=2556) | Tjaden Hess | Apr 2025 | Cryptography & blockchain |
 | [Security Weekly 323](https://youtu.be/zn3LT4BqOJo?si=3zY5YkRU4ArgM-vn) | Keith Hoodlet | Mar 2025 | GenAI in Appsec |
 | [Xyonix](https://youtu.be/y8TF7MELevg?si=gv60OR2_L86fsL2L) | Keith Hoodlet | Mar 2025 | AI/ML security |
-| [The Impulsive Thinker](https://theimpulsivethinker.libsyn.com/unlocking-ai-a-tool-not-a-magic-bullet-for-adhd-entrepreneurs) | Dan Guido | Feb 2025 | Mental health & neurodivergence |
+| [The Impulsive Thinker](https://theimpulsivethinker.libsyn.com/unlocking-ai-a-tool-not-a-magic-bullet-for-adhd-entrepreneurs) | Dan Guido | Feb 2025 | Neurodivergence |
 | [Bugcrowd](https://youtu.be/b7EULU_X7fQ?si=DZFenK1x00PaD5yV) | Keith Hoodlet | Oct 2024 | AI/ML Bias |
 | [Risky Biz](https://risky.biz/RBNEWSSI62/)  | Dan Guido | Oct 2024 | Post-quantum cryptography |
 | [Risky Biz 759](https://youtu.be/4zpPk3Y4CYA?si=Pvd8px1DQHRPsRtM&t=3046)  | Dan Guido | Aug 2024 | DARPA's AI Cyber Challenge |


### PR DESCRIPTION
## Summary
- Add Risky Biz sponsored interview with Dan Guido (Feb 2026) — AI at Trail of Bits
- Add What's in the SOSS? #53 with Michael Brown (Feb 2026) — AIxCC & Buttercup
- Add Open Source Security with William Woodruff (May 2025) — Zizmor & GitHub Actions security
- Add The Impulsive Thinker with Dan Guido (Feb 2025) — AI as a practical tool

## Test plan
- [ ] Verify all podcast links resolve correctly
- [ ] Verify entries are sorted by date (newest first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)