### PR TITLE
Add The Smartest Contract podcast archive link

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@
 | [Risky Biz 526](https://risky.biz/RB526/) | JP Smith | Jan 2019 | Post-quantum crypto in CTFs |
 | [Absolute AppSec 37](https://www.youtube.com/watch?v=beGo7l0u5cY) | Stefan Edwards | Nov 2018 | Programming languages,  symbex |
 | [Risky Biz 510](https://risky.biz/RB510/) | Lauren Pearl | Aug 2018 | Open source security engineering |
+| [The Smartest Contract 15](https://web.archive.org/web/20181018135712/http://www.thesmartestcontract.com/15) | JP Smith | Aug 2018 | Trail of Bits security tools & auditing |
 | [Absolute AppSec 34](https://www.youtube.com/watch?v=gtikYoT6vKc) | Stefan Edwards | Oct 2018 | Security testing, blockchain |
 | [Zero Knowledge 16](https://www.zeroknowledge.fm/16) | JP Smith | Mar 2018 | Smart contract security |
 | [Risky Biz 488](https://risky.biz/RB488/) | JP Smith | Feb 2018 | Smart contract testing w/ Manticore |


### PR DESCRIPTION
## Summary

- Adds Episode 15 of "The Smartest Contract" podcast (JP Smith, Aug 2018) to the Podcasts table
- Links to the Wayback Machine archive since the original site (thesmartestcontract.com) is defunct

## Research findings

The podcast was hosted on Fireside.fm by Jeffrey Tong (@itsjefftong). Through the Wayback Machine's CDX API, I recovered the archived homepage, RSS feed, and episode metadata:

| Source | Status |
|--------|--------|
| Wayback Machine (homepage + RSS) | Archived |
| Fireside.fm CDN (audio MP3) | Deleted |
| Apple Podcasts | Removed |
| Spotify | Removed |
| PocketCasts | Listed but episode 15 not visible on web |

The audio file (26:24, ~16MB) has been permanently deleted from Fireside.fm's CDN and was never captured by the Wayback Machine. No recoverable copy of the audio was found.

Refs #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)